### PR TITLE
Implement fast SISO time delay

### DIFF
--- a/controlboros/__init__.py
+++ b/controlboros/__init__.py
@@ -13,4 +13,5 @@ from .controlboros import (
     StateSpaceBuilder,
     RateWrapper,
     TimeDelay,
+    FastSISOTimeDelay,
     )

--- a/controlboros/__init__.py
+++ b/controlboros/__init__.py
@@ -13,5 +13,5 @@ from .controlboros import (
     StateSpaceBuilder,
     RateWrapper,
     TimeDelay,
-    FastSISOTimeDelay,
+    FastSisoTimeDelay,
     )

--- a/controlboros/controlboros.py
+++ b/controlboros/controlboros.py
@@ -823,7 +823,15 @@ class FastSisoTimeDelay(AbstractSystem):
 
     On the other hand, methods :meth:`set_state`, :meth:`set_state_to_zero`,
     :meth:`get_state` and :meth:`push_stateful` offer an interface similar
-    to the standard models derived from :class:`AbstractSystem` .
+    to the standard models derived from :class:`AbstractSystem`.
+
+    Note
+    ----
+    In contrast to :class:`TimeDelay`, this system input and output is
+    a scalar ``float``, not an ``ndarray`` of shape ``(1,)``!
+
+    However, you can *still* push an ``ndarray`` into this time delay line;
+    in this case, the performance will be severely reduced.
 
     """
 

--- a/controlboros/controlboros.py
+++ b/controlboros/controlboros.py
@@ -831,7 +831,7 @@ class FastSisoTimeDelay(AbstractSystem):
         if num_samples <= 0:
             raise ValueError("Number of delay samples must be greater than 0.")
 
-        self._state = deque(np.zeros((num_samples,)), maxlen=num_samples)
+        self._state = deque(np.zeros((num_samples,)), maxlen=(num_samples + 1))
 
     def get_state(self):
         """Get current system state.
@@ -855,12 +855,12 @@ class FastSisoTimeDelay(AbstractSystem):
         """
         temp_state = np.empty((len(self._state),))
         temp_state[:] = np.array(state)
-        self._state = deque(temp_state, maxlen=len(temp_state))
+        self._state = deque(temp_state, maxlen=(len(temp_state) + 1))
 
     def set_state_to_zero(self):
         """Set current system state to zeros."""
         old_len = len(self._state)
-        self._state = deque(np.zeros((old_len,)), maxlen=old_len)
+        self._state = deque(np.zeros((old_len,)), maxlen=(old_len + 1))
 
     def push_stateful(self, inp):
         """Push an input into system, get the output, update system state.

--- a/controlboros/controlboros.py
+++ b/controlboros/controlboros.py
@@ -880,13 +880,13 @@ class FastSISOTimeDelay(AbstractSystem):
         return self._state.popleft()
 
     def push_pure(self, state, inp):
-        """This function is not used in the fast implementation."""
-        raise NotImplemented
+        """Do not use this function."""
+        return None
 
     def dynamics(self, state, inp):
-        """This function is not used in the fast implementation."""
-        raise NotImplemented
+        """Do not use this function."""
+        return None
 
     def output(self, state, inp):
-        """This function is not used in the fast implementation."""
-        raise NotImplemented
+        """Do not use this function."""
+        return None

--- a/controlboros/controlboros.py
+++ b/controlboros/controlboros.py
@@ -799,8 +799,10 @@ class TimeDelay(AbstractSystem):
 class FastSisoTimeDelay(AbstractSystem):
     r"""Fast SISO discrete time delay system.
 
-    This object provides a :math:`m` samples long delay line.
-    It supports only scalar signals and is faster than :class:`TimeDelay`.
+    This object provides a :math:`m` samples long delay line only
+    for scalar signals. Since it uses a deque as a buffer with O(1) push
+    and pop costs at both ends, it is significantly faster than the
+    standard MIMO :class:`TimeDelay`.
 
     Its state vector is given by the following vector
     of dimension :math:`m`:
@@ -813,6 +815,15 @@ class FastSisoTimeDelay(AbstractSystem):
             x[k - 2] \\
             x[k - 1] \\
         \end{bmatrix}
+
+    Note
+    ----
+    Due to its lower-level implementation, this class does not implement
+    methods :meth:`push_pure`, :meth:`dynamics` and :meth:`output`.
+
+    On the other hand, methods :meth:`set_state`, :meth:`set_state_to_zero`,
+    :meth:`get_state` and :meth:`push_stateful` offer an interface similar
+    to the standard models derived from :class:`AbstractSystem` .
 
     """
 

--- a/controlboros/controlboros.py
+++ b/controlboros/controlboros.py
@@ -51,10 +51,10 @@ Some useful systems
     :undoc-members:
     :show-inheritance:
 
-:class:`FastSISOTimeDelay`
+:class:`FastSisoTimeDelay`
 --------------------------
 
-.. autoclass:: FastSISOTimeDelay
+.. autoclass:: FastSisoTimeDelay
     :members:
     :undoc-members:
     :show-inheritance:
@@ -796,7 +796,7 @@ class TimeDelay(AbstractSystem):
         return state[:self.dim]
 
 
-class FastSISOTimeDelay(AbstractSystem):
+class FastSisoTimeDelay(AbstractSystem):
     r"""Fast SISO discrete time delay system.
 
     This object provides a :math:`m` samples long delay line.

--- a/controlboros/tests/test_time_delay.py
+++ b/controlboros/tests/test_time_delay.py
@@ -1,5 +1,5 @@
 """Tests the time delay system."""
-from controlboros import TimeDelay
+from controlboros import TimeDelay, FastSisoTimeDelay
 import numpy as np
 import pytest
 
@@ -69,3 +69,85 @@ def test_delay_high_level():
     assert np.all(td.push_stateful([4.0]) == [1.0])
     assert np.all(td.push_stateful([5.0]) == [2.0])
     assert np.all(td.push_stateful([6.0]) == [3.0])
+
+
+def test_fast_delay_exception_delay_non_integer():
+    """Test exception if num samples is not integer."""
+    with pytest.raises(ValueError) as excinfo:
+        FastSisoTimeDelay(1.1)
+    assert "Number of delay samples must be an integer" in str(excinfo.value)
+
+
+def test_fast_delay_exception_delay_leq_zero():
+    """Test exception if num samples is less or equal 0."""
+    ref_msg = "Number of delay samples must be greater than 0"
+
+    with pytest.raises(ValueError) as excinfo:
+        FastSisoTimeDelay(0)
+    assert ref_msg in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        FastSisoTimeDelay(-1)
+    assert ref_msg in str(excinfo.value)
+
+
+def test_fast_delay_dynamics():
+    """Test fast delay line dynamics."""
+    td = FastSisoTimeDelay(2)
+    assert td.dynamics(1, 1) is None
+
+
+def test_fast_delay_output():
+    """Test fast delay line output."""
+    td = FastSisoTimeDelay(2)
+    assert td.output(1, 1) is None
+
+
+def test_fast_delay_push_pure():
+    """Test fast delay line stateless push function."""
+    td = FastSisoTimeDelay(2)
+    assert td.push_pure(1, 1) is None
+
+
+def test_fast_delay_high_level():
+    """Test fast delay line -- high-level test."""
+    td = FastSisoTimeDelay(3)
+    assert td.push_stateful(1.0) == 0.0
+    assert td.push_stateful(2.0) == 0.0
+    assert td.push_stateful(3.0) == 0.0
+    assert td.push_stateful(4.0) == 1.0
+    assert td.push_stateful(5.0) == 2.0
+    assert td.push_stateful(6.0) == 3.0
+
+
+def test_fast_delay_get_state():
+    """Test fast delay line state getter."""
+    td = FastSisoTimeDelay(3)
+    assert td.push_stateful(1.0) == 0.0
+    assert td.push_stateful(2.0) == 0.0
+    assert td.push_stateful(3.0) == 0.0
+    assert np.all(td.get_state() == [1.0, 2.0, 3.0])
+
+
+def test_fast_delay_set_state():
+    """Test fast delay line state setter."""
+    td = FastSisoTimeDelay(3)
+    td.set_state([1.0, 2.0, 3.0])
+    assert td.push_stateful(4.0) == 1.0
+    assert td.push_stateful(5.0) == 2.0
+    assert td.push_stateful(6.0) == 3.0
+    assert td.push_stateful(0.0) == 4.0
+    assert td.push_stateful(0.0) == 5.0
+    assert td.push_stateful(0.0) == 6.0
+
+
+def test_fast_delay_set_state_to_zero():
+    """Test fast delay line state-to-zero setter."""
+    td = FastSisoTimeDelay(3)
+    assert td.push_stateful(1.0) == 0.0
+    assert td.push_stateful(2.0) == 0.0
+    assert td.push_stateful(3.0) == 0.0
+    td.set_state_to_zero()
+    assert td.push_stateful(4.0) == 0.0
+    assert td.push_stateful(5.0) == 0.0
+    assert td.push_stateful(6.0) == 0.0


### PR DESCRIPTION
This time delay line is limited to scalar systems. Hence, we can use a deque and make the push/pop operations much faster than matrix concatenation and reshaping as it is done in the standard `TimeDelay` class.

## Advantages
`FastSisoTimeDelay` :rabbit2: is significantly faster than `TimeDelay` :turtle:

## Drawbacks
* `FastSisoTimeDelay` is limited to scalar systems
* `FastSisoTimeDelay` breaks the API at some points:
    * pushes and pops are done with scalar `float`, not with `ndarray` of shape `(1,)`
    * it has no pure implementation, so some methods are unusable